### PR TITLE
Move to upstream rubycritic github.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'byebug', group: %i[development test]
-gem 'rubycritic', git: 'https://github.com/whitesmith/rubycritic'

--- a/rubycritic-small-badge.gemspec
+++ b/rubycritic-small-badge.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rubocop', '~> 0.65'
+  s.add_development_dependency 'rubycritic', '~> 4.0.2'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'simplecov-small-badge', '~> 0.2.2'
 


### PR DESCRIPTION
* bump rubycritic to 4.0.2 that will support this gem