### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rubycritic-small-badge.gemspec
+++ b/rubycritic-small-badge.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.summary     = %(Small Badge generator for RubyCritic analysis tool for ruby)
   s.description = %(Small Badge generator for RubyCritic coverage tool for ruby)
 
-  s.rubyforge_project = 'rubycritic-small-badge'
-
   s.add_dependency 'repo-small-badge', '~> 0.2.5'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.