### PR TITLE
Update README with fixed rake example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RubyCriticSmallBadge.configure do |config|
   config.minimum_score = 90
 end
 RubyCritic::RakeTask.new do |task|
-  task.options = %(--formatter RubyCriticSmallBadge::Report
+  task.options = %(--custom-format RubyCriticSmallBadge::Report
 --minimum-score #{RubyCriticSmallBadge.config.minimum_score})
 end
 ```


### PR DESCRIPTION
rubycritic seems to have changed their options names.